### PR TITLE
Select datastore available on esxi_hostname if provided

### DIFF
--- a/lib/ansible/modules/cloud/vmware/vmware_guest.py
+++ b/lib/ansible/modules/cloud/vmware/vmware_guest.py
@@ -1916,7 +1916,11 @@ class PyVmomiHelper(PyVmomi):
             # TODO: really use the datastore for newly created disks
             if 'autoselect_datastore' in self.params['disk'][0] and self.params['disk'][0]['autoselect_datastore']:
                 datastores = self.cache.get_all_objs(self.content, [vim.Datastore])
-                datastores = [x for x in datastores if self.cache.get_parent_datacenter(x).name == self.params['datacenter']]
+                if self.params['esxi_hostname']:
+                    # Filtering datastores to those one attached to esxi host selected (it could be local storage)
+                    datastores = [x for x in datastores if self.params['esxi_hostname'].split(".",1)[0] in [h.key.config.network.netStackInstance[0].dnsConfig.hostName for h in x.host]]
+                else:
+                    datastores = [x for x in datastores if self.cache.get_parent_datacenter(x).name == self.params['datacenter']]
                 if datastores is None or len(datastores) == 0:
                     self.module.fail_json(msg="Unable to find a datastore list when autoselecting")
 


### PR DESCRIPTION
##### SUMMARY
The issue is how the datastore is selected when autoselect_datastore is True (default value) and you also use the esxi_hostname param.

At the moment for ansible 2.7.x you select the datstore present in the cluster with more free space that it's ok for cluster with distributed storage.
But if a cluster has local storage on the nodes that could end in select a datastore not attached to the designed esxi_hostname param and thus creating the new vm on the wrong esxi_hostname.

So I modified the PyVmomiHelper.select_datastore function so in case esxi_hostname is defined only datastores attached to that esxi are used.

Unfortunately, I only have this VMware infra so I can't test with distributed storage.

Fixes #56467

##### ISSUE TYPE
<!--- Pick one below and delete the rest -->
- Bugfix Pull Request

##### COMPONENT NAME
<!--- Write the short name of the module, plugin, task or feature below -->
vmware_guest


##### ADDITIONAL INFORMATION
<!--- Include additional information to help people understand the change here -->
<!--- A step-by-step reproduction of the problem is helpful if there is no related issue -->
In a Cluster with esxi hosts not using shared storage using esxi_hostname is ignored as it uses the datastore with more free space on the cluster not the esxi's host datastore with more free space.
<!--- Paste verbatim command output below, e.g. before and after your change -->
```paste below
- name: VMware test
  hosts: localhost
  connection: local
  gather_facts: false
  tasks:

    - name: Other task name
      vmware_guest:
        hostname: "vclabcpd.lab.XXXX.es"
        port: "443"
        username: "YOURUSER"
        password: "YOURPASS"
        #cluster: "Lab_CPD_Old"
        esxi_hostname: "10.200.1.103"
        datacenter: "Laboratorio_CPD_Old"
        validate_certs: False
        name: "sn8845.test"
        folder: "8845"
        guest_id: 'rhel6_64Guest'
        disk:
          - size_gb: 300 # in GB
            type: thin # Valid values: "thin" or "eagerzeroedthick"
            autoselect_datastore: True
          - size_gb: 300 # in GB
            type: thin # Valid values: "thin" or "eagerzeroedthick"
            autoselect_datastore: True 
        hardware: 
          num_cpus: 8
          memory_mb: 8192 # in MB
          version: 8.0
        networks:
          - name: "8845-srv"
            device_type: "vmxnet3"
            network: "10.{{ ((8845|int * 2) / 256)|int }}.{{ ((8845|int * 2) % 256)|int }}.0"
            ip: "10.{{ ((8845|int * 2) / 256)|int }}.{{ ((8845|int * 2) % 256)|int }}.9"
            gateway: "10.{{ ((8845|int * 2) / 256)|int }}.{{ ((8845|int * 2) % 256)|int }}.1"
            netmask: "255.255.255.128"
            vmnet: "8845-srv"
            dns:
              itg: "172.20.2.11"
              pre: "172.28.62.1"
              pro: "172.20.2.11"
        state: present

BEFORE the CHANGE

changed: [localhost] => {
    "changed": true,
    "instance": {
        "annotation": "",
        "current_snapshot": null,
        "customvalues": {},
        "guest_consolidation_needed": false,
        "guest_question": null,
        "guest_tools_status": "guestToolsNotRunning",
        "guest_tools_version": "0",
        "hw_cluster": "Lab_CPD_Old",
        "hw_cores_per_socket": 1,
        "hw_datastores": [
            "10.200.1.105_datastore1"
        ],
        "hw_esxi_host": "10.200.1.105",
        "hw_eth0": {
            "addresstype": "assigned",
            "ipaddresses": null,
            "label": "Network adapter 1",
            "macaddress": "00:50:56:ab:1c:69",
            "macaddress_dash": "00-50-56-ab-1c-69",
            "portgroup_key": null,
            "portgroup_portkey": null,
            "summary": "8845-srv"
        },
        "hw_files": [
            "[10.200.1.105_datastore1] sn8845.test/sn8845.test.vmx",
            "[10.200.1.105_datastore1] sn8845.test/sn8845.test.vmxf",
            "[10.200.1.105_datastore1] sn8845.test/sn8845.test.vmsd",
            "[10.200.1.105_datastore1] sn8845.test/sn8845.test.vmdk",
            "[10.200.1.105_datastore1] sn8845.test/sn8845.test_1.vmdk"
        ],
        "hw_folder": "/Laboratorio_CPD_Old/vm/8845",
        "hw_guest_full_name": null,
        "hw_guest_ha_state": null,
        "hw_guest_id": null,
        "hw_interfaces": [
            "eth0"
        ],
        "hw_is_template": false,
        "hw_memtotal_mb": 8192,
        "hw_name": "sn8845.test",
        "hw_power_status": "poweredOff",
        "hw_processor_count": 8,
        "hw_product_uuid": "422b027a-1895-c12c-0503-6b0a5158115c",
        "hw_version": "vmx-08",
        "instance_uuid": "502b7768-7853-1844-bb3e-1c4d15f13731",
        "ipv4": null,
        "ipv6": null,
        "module_hw": true,
        "snapshots": [],
        "vnc": {}
    },
    "invocation": {
        "module_args": {
            "annotation": null,
            "cdrom": {},
            "cluster": null,
            "convert": null,
            "customization": {},
            "customization_spec": null,
            "customvalues": [],
            "datacenter": "Laboratorio_CPD_Old",
            "datastore": null,
            "disk": [
                {
                    "autoselect_datastore": true,
                    "size_gb": 300,
                    "type": "thin"
                },
                {
                    "autoselect_datastore": true,
                    "size_gb": 300,
                    "type": "thin"
                }
            ],
            "esxi_hostname": "10.200.1.103",
            "folder": "8845",
            "force": false,
            "guest_id": "rhel6_64Guest",
            "hardware": {
                "memory_mb": 8192,
                "num_cpus": 8,
                "version": 8.0
            },
            "hostname": "vclabcpd.lab.XXXXX.es",
            "is_template": false,
            "linked_clone": false,
            "name": "sn8845.test",
            "name_match": "first",
            "networks": [
                {
                    "device_type": "vmxnet3",
                    "dns": {
                        "itg": "172.20.2.11",
                        "pre": "172.28.62.1",
                        "pro": "172.20.2.11"
                    },
                    "gateway": "10.69.26.1",
                    "ip": "10.69.26.9",
                    "name": "8845-srv",
                    "netmask": "255.255.255.128",
                    "network": "10.69.26.0",
                    "type": "static",
                    "vmnet": "8845-srv"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "resource_pool": null,
            "snapshot_src": null,
            "state": "present",
            "state_change_timeout": 0,
            "template": null,
            "use_instance_uuid": false,
            "username": "USERNAME",
            "uuid": null,
            "validate_certs": false,
            "vapp_properties": [],
            "wait_for_customization": false,
            "wait_for_ip_address": false
        }
    }
}

AFTER the CHANGE

changed: [localhost] => {
    "changed": true,
    "instance": {
        "annotation": "",
        "current_snapshot": null,
        "customvalues": {},
        "guest_consolidation_needed": false,
        "guest_question": null,
        "guest_tools_status": "guestToolsNotRunning",
        "guest_tools_version": "0",
        "hw_cores_per_socket": 1,
        "hw_datastores": [
            "10.200.1.103_datastore1"
        ],
        "hw_esxi_host": "10.200.1.103",
        "hw_eth0": {
            "addresstype": "assigned",
            "ipaddresses": null,
            "label": "Network adapter 1",
            "macaddress": "00:50:56:ab:d3:27",
            "macaddress_dash": "00-50-56-ab-d3-27",
            "portgroup_key": null,
            "portgroup_portkey": null,
            "summary": "8845-srv"
        },
        "hw_files": [
            "[10.200.1.103_datastore1] sn8845.test/sn8845.test.vmx",
            "[10.200.1.103_datastore1] sn8845.test/sn8845.test.vmxf",
            "[10.200.1.103_datastore1] sn8845.test/sn8845.test.vmsd",
            "[10.200.1.103_datastore1] sn8845.test/sn8845.test.vmdk",
            "[10.200.1.103_datastore1] sn8845.test/sn8845.test_1.vmdk"
        ],
        "hw_folder": "/Laboratorio_CPD_Old/vm/8845",
        "hw_guest_full_name": null,
        "hw_guest_ha_state": null,
        "hw_guest_id": null,
        "hw_interfaces": [
            "eth0"
        ],
        "hw_is_template": false,
        "hw_memtotal_mb": 8192,
        "hw_name": "sn8845.test",
        "hw_power_status": "poweredOff",
        "hw_processor_count": 8,
        "hw_product_uuid": "422b1b32-b922-7f4c-54d1-1032493165c8",
        "hw_version": "vmx-08",
        "instance_uuid": "502b7b64-23c5-2317-8817-0894f2996859",
        "ipv4": null,
        "ipv6": null,
        "module_hw": true,
        "snapshots": []
    },
    "invocation": {
        "module_args": {
            "annotation": null,
            "cdrom": {},
            "cluster": null,
            "customization": {},
            "customization_spec": null,
            "customvalues": [],
            "datacenter": "Laboratorio_CPD_Old",
            "datastore": null,
            "disk": [
                {
                    "autoselect_datastore": true,
                    "size_gb": 300,
                    "type": "thin"
                },
                {
                    "autoselect_datastore": true,
                    "size_gb": 300,
                    "type": "thin"
                }
            ],
            "esxi_hostname": "10.200.1.103",
            "folder": "8845",
            "force": false,
            "guest_id": "rhel6_64Guest",
            "hardware": {
                "memory_mb": 8192,
                "num_cpus": 8,
                "version": 8.0
            },
            "hostname": "vclabcpd.lab.XXXXX.es",
            "is_template": false,
            "linked_clone": false,
            "name": "sn8845.test",
            "name_match": "first",
            "networks": [
                {
                    "device_type": "vmxnet3",
                    "dns": {
                        "itg": "172.20.2.11",
                        "pre": "172.28.62.1",
                        "pro": "172.20.2.11"
                    },
                    "gateway": "10.69.26.1",
                    "ip": "10.69.26.9",
                    "name": "8845-srv",
                    "netmask": "255.255.255.128",
                    "network": "10.69.26.0",
                    "type": "static",
                    "vmnet": "8845-srv"
                }
            ],
            "password": "VALUE_SPECIFIED_IN_NO_LOG_PARAMETER",
            "port": 443,
            "resource_pool": null,
            "snapshot_src": null,
            "state": "present",
            "state_change_timeout": 0,
            "template": null,
            "username": "USERNAMES",
            "uuid": null,
            "validate_certs": false,
            "vapp_properties": [],
            "wait_for_ip_address": false
        }
    }
}
```
